### PR TITLE
Add Graph class complement method

### DIFF
--- a/mygraph.py
+++ b/mygraph.py
@@ -228,6 +228,11 @@ class Graph(object):
         """
         return 'V=[' + ", ".join(map(str, self._v)) + ']\nE=[' + ", ".join(map(str, self._e)) + ']'
 
+    def __eq__(self, other):
+        if isinstance(self, other.__class__):
+            return self.__dict__ == other.__dict__
+        return NotImplemented
+
     def _next_label(self) -> int:
         """
         Generates unique labels for vertices within the graph

--- a/mygraph.py
+++ b/mygraph.py
@@ -209,6 +209,7 @@ class Graph(object):
         self._simple = simple
         self._directed = directed
         self._next_label_value = 0
+        self._tag = None
 
         for i in range(n):
             self.add_vertex(Vertex(self))
@@ -218,7 +219,18 @@ class Graph(object):
         A programmer-friendly representation of the Graph.
         :return: The string to approximate the constructor arguments of the `Graph'
         """
-        return 'Graph(directed={}, simple={}, #edges={n_edges}, #vertices={n_vertices})'.format(
+
+        tag_string = ''
+        if self._tag is not None:
+            tag_string = f'tag="{self._tag}", '
+
+        return \
+            'Graph(' \
+            + tag_string + \
+            'directed={}, ' \
+            'simple={}, ' \
+            '#edges={n_edges}, ' \
+            '#vertices={n_vertices})'.format(
             self._directed, self._simple, n_edges=len(self._e), n_vertices=len(self._v))
 
     def __str__(self) -> str:
@@ -226,7 +238,15 @@ class Graph(object):
         A user-friendly representation of this graph
         :return: A textual representation of the vertices and edges of this graph
         """
-        return 'V=[' + ", ".join(map(str, self._v)) + ']\nE=[' + ", ".join(map(str, self._e)) + ']'
+
+        tag_string = ''
+        if self._tag is not None:
+            tag_string = f'"{self._tag}"\n'
+
+        return \
+            tag_string + \
+            'V=[{0}]\n' \
+            'E=[{1}]'.format(", ".join(map(str, self._v)), ", ".join(map(str, self._e)))
 
     def __eq__(self, other):
         if isinstance(self, other.__class__):
@@ -271,6 +291,14 @@ class Graph(object):
         :return: The `set` of edges of the graph
         """
         return list(self._e)
+
+    @property
+    def tag(self):
+        return self._tag
+
+    @tag.setter
+    def tag(self, tag):
+        self._tag = tag
 
     def __iter__(self):
         """

--- a/mygraph.py
+++ b/mygraph.py
@@ -281,16 +281,16 @@ class Graph(object):
     @property
     def vertices(self) -> List["Vertex"]:
         """
-        :return: The `set` of vertices of the graph
+        :return: The `list` of vertices of the graph
         """
-        return list(self._v)
+        return self._v
 
     @property
     def edges(self) -> List["Edge"]:
         """
-        :return: The `set` of edges of the graph
+        :return: The `list` of edges of the graph
         """
-        return list(self._e)
+        return self._e
 
     @property
     def tag(self):
@@ -326,7 +326,6 @@ class Graph(object):
         for e in vertex.incidence:
             self.del_edge(e)
         self._v.remove(vertex)
-
 
     def add_edge(self, edge: "Edge"):
         """

--- a/mygraph.py
+++ b/mygraph.py
@@ -197,7 +197,7 @@ class Edge(object):
 
 
 class Graph(object):
-    def __init__(self, directed: bool, n: int=0, simple: bool=False):
+    def __init__(self, directed: bool = False, n: int = 0, simple: bool = False):
         """
         Creates a graph.
         :param directed: Whether the graph should behave as a directed graph.

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -8,13 +8,21 @@ class Tests(unittest.TestCase):
 
     def setUp(self):
         # Instantiate the empty graph
-        self.empty_graph = Graph()
+        empty_graph = Graph()
+        # empty_graph.tag = 'empty_graph'  # Don't uncomment
+        self.empty_graph = empty_graph
 
         # Instantiate a connected graph of order 2
         connected_graph_order_2 = Graph(n=2)
         vertices = connected_graph_order_2.vertices
         connected_graph_order_2.add_edge(Edge(tail=vertices[0], head=vertices[1]))
+        connected_graph_order_2.tag = 'connected_graph_order_2'
         self.connected_graph_order_2 = connected_graph_order_2
+
+        # Instantiate the disconnected graph of order 2, which is the complement of a connected graph of order 2
+        disconnected_graph_order_2 = Graph(n=2)
+        # disconnected_graph_order_2 = 'disconnected_graph_order_2'  # Don't uncomment
+        self.disconnected_graph_order_2 = disconnected_graph_order_2
 
         # Instantiate a non-trivial graph
         non_trivial_graph = Graph(n=5)
@@ -24,18 +32,27 @@ class Tests(unittest.TestCase):
         non_trivial_graph.add_edge(Edge(vertices[1], vertices[4]))
         non_trivial_graph.add_edge(Edge(vertices[2], vertices[3]))
         non_trivial_graph.add_edge(Edge(vertices[3], vertices[4]))
+        non_trivial_graph.tag = 'non_trivial_graph'
         self.non_trivial_graph = non_trivial_graph
 
         # Create two instances of the same non-trivial graph, each with one different sub-element field
         non_trivial_graph_different_label = deepcopy(self.non_trivial_graph)
         non_trivial_graph_different_label.vertices[0].label = 'spam'
+        non_trivial_graph_different_label.tag = 'non_trivial_graph_different_label'
         self.non_trivial_graph_different_label = non_trivial_graph_different_label
 
         non_trivial_graph_different_weight = deepcopy(self.non_trivial_graph)
         edge = non_trivial_graph_different_weight.edges[0]
         non_trivial_graph_different_weight.del_edge(edge)
         non_trivial_graph_different_weight.add_edge(Edge(tail=edge.tail, head=edge.head, weight=1))
+        non_trivial_graph_different_weight.tag = 'non_trivial_graph_different_weight'
         self.non_trivial_graph_different_weight = non_trivial_graph_different_weight
+
+    def test_mygraph_graph_tag(self):
+        graph = Graph()
+        self.assertEqual(None, graph.tag)
+        graph.tag = 'spam'
+        self.assertEqual('spam', graph.tag)
 
     def test_mygraph_graph_eq(self):
         # Assert that a graph is not an object of a different type
@@ -43,7 +60,11 @@ class Tests(unittest.TestCase):
 
         # Assert that the empty graph is equal to itself
         self.assertEqual(self.empty_graph, self.empty_graph)
-        self.assertEqual(Graph(), self.empty_graph)
+
+        # Assert that the tagless empty graph is unequal to the empty graph with a tag
+        graph = Graph()
+        graph.tag = 'spam'
+        self.assertNotEqual(self.empty_graph, graph)
 
         # Assert that a non-trivial graph is equal to itself
         self.assertEqual(self.non_trivial_graph, self.non_trivial_graph)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,57 @@
+import unittest
+from copy import deepcopy
+
+from mygraph import Graph, Edge
+
+
+class Tests(unittest.TestCase):
+
+    def setUp(self):
+        # Instantiate the empty graph
+        self.empty_graph = Graph()
+
+        # Instantiate a connected graph of order 2
+        connected_graph_order_2 = Graph(n=2)
+        vertices = connected_graph_order_2.vertices
+        connected_graph_order_2.add_edge(Edge(tail=vertices[0], head=vertices[1]))
+        self.connected_graph_order_2 = connected_graph_order_2
+
+        # Instantiate a non-trivial graph
+        non_trivial_graph = Graph(n=5)
+        vertices = non_trivial_graph.vertices
+        non_trivial_graph.add_edge(Edge(vertices[0], vertices[1]))
+        non_trivial_graph.add_edge(Edge(vertices[1], vertices[2]))
+        non_trivial_graph.add_edge(Edge(vertices[1], vertices[4]))
+        non_trivial_graph.add_edge(Edge(vertices[2], vertices[3]))
+        non_trivial_graph.add_edge(Edge(vertices[3], vertices[4]))
+        self.non_trivial_graph = non_trivial_graph
+
+        # Create two instances of the same non-trivial graph, each with one different sub-element field
+        non_trivial_graph_different_label = deepcopy(self.non_trivial_graph)
+        non_trivial_graph_different_label.vertices[0].label = 'spam'
+        self.non_trivial_graph_different_label = non_trivial_graph_different_label
+
+        non_trivial_graph_different_weight = deepcopy(self.non_trivial_graph)
+        edge = non_trivial_graph_different_weight.edges[0]
+        non_trivial_graph_different_weight.del_edge(edge)
+        non_trivial_graph_different_weight.add_edge(Edge(tail=edge.tail, head=edge.head, weight=1))
+        self.non_trivial_graph_different_weight = non_trivial_graph_different_weight
+
+    def test_mygraph_graph_eq(self):
+        # Assert that a graph is not an object of a different type
+        self.assertNotEqual(None, Graph())
+
+        # Assert that the empty graph is equal to itself
+        self.assertEqual(self.empty_graph, self.empty_graph)
+        self.assertEqual(Graph(), self.empty_graph)
+
+        # Assert that a non-trivial graph is equal to itself
+        self.assertEqual(self.non_trivial_graph, self.non_trivial_graph)
+
+        # Assert that a non-trivial graph and others with the same structure but with different sub-element fields
+        # are unequal
+        self.assertNotEqual(self.non_trivial_graph, self.non_trivial_graph_different_label)
+        self.assertNotEqual(self.non_trivial_graph, self.non_trivial_graph_different_weight)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Implements #3.

This PR adds a `complement` method to the `Graph` class.

The following is tested:
1. Assert that the complement of the empty graph is the empty graph
1. Assert that the complement of the singly connected graph of order 2 is the disconnected graph of order 2
1. Assert that the complement of the complement of a graph is the graph itself (only true for non-multigraphs)
1. Assert that the complement of a non-trivial graph is correctly constructed

For the tests to work, I needed to implement the `==` operator (by implementing the `__eq__` method). Two graphs are equal by the `==` operator if the contents of their attributes are equal.

Curious paradoxical recursion: to properly test if the `complement` method does its job correctly, we need to check if the calculated complement is an _isomorphism_ of the expected graph... So: I tested this by comparing the Python objects being structurally equivalent (more or less), which only defines an isomorphism if all object attributes are equal (by the `==` operator).