### PR TITLE
Enhance Graph class (and friends)

### DIFF
--- a/mygraph.py
+++ b/mygraph.py
@@ -228,6 +228,11 @@ class Graph(object):
         """
         return 'V=[' + ", ".join(map(str, self._v)) + ']\nE=[' + ", ".join(map(str, self._e)) + ']'
 
+    def __eq__(self, other):
+        if isinstance(self, other.__class__):
+            return self.__dict__ == other.__dict__
+        return NotImplemented
+
     def _next_label(self) -> int:
         """
         Generates unique labels for vertices within the graph

--- a/mygraph.py
+++ b/mygraph.py
@@ -120,8 +120,8 @@ class Edge(object):
     """
 
     def __init__(self, tail: Vertex, head: Vertex, weight=None):
-        """
-        Creates an edge between vertices `tail` and `head`
+        """Creates an edge with optional weight between two vertices.
+
         :param tail: In case the graph is directed, this is the tail of the arrow.
         :param head: In case the graph is directed, this is the head of the arrow.
         :param weight: Optional weight of the vertex, which can be any type, but usually is a number.
@@ -132,15 +132,15 @@ class Edge(object):
         self._weight = weight
 
     def __repr__(self):
-        """
-        A programmer-friendly representation of the edge.
+        """A programmer-friendly representation of the edge.
+
         :return: The string to approximate the constructor arguments of the `Edge'
         """
         return 'Edge(head={}, tail={}, weight={})'.format(self.head.label, self.tail.label, self.weight)
 
     def __str__(self) -> str:
-        """
-        A user friendly representation of this edge
+        """A user friendly representation of this edge.
+
         :return: A user friendly representation of this edge
         """
         return '({}, {})'.format(str(self.tail), str(self.head))
@@ -246,9 +246,8 @@ class Graph(Hashable):
             + tag_string + \
             'directed={}, ' \
             'simple={}, ' \
-            '#edges={n_edges}, ' \
-            '#vertices={n_vertices})'.format(
-            self._directed, self._simple, n_edges=len(self._e), n_vertices=len(self._v))
+            '#edges={}, ' \
+            '#vertices={})'.format(self._directed, self._simple, len(self._e), len(self._v))
 
     def __str__(self) -> str:
         """
@@ -336,10 +335,10 @@ class Graph(Hashable):
         vertex.graphs.remove(self)
 
     def add_edge(self, edge: "Edge"):
-        """
-        Add an edge to the graph. And if necessary also the vertices.
-        Includes some checks in case the graph should stay simple.
-        :param edge: The edge to be added
+        """Add an edge to the graph. If necessary, also add the vertices. Some checks if the graph should stay simple
+        are included.
+
+        :param Edge edge: The edge to be added.
         """
 
         if self._simple:
@@ -426,42 +425,3 @@ class Graph(Hashable):
         """
         return v in u.neighbours and (not self.directed or any(e.head == v for e in u.incidence))
 
-
-class UnsafeGraph(Graph):
-    @property
-    def vertices(self) -> List["Vertex"]:
-        return self._v
-
-    @property
-    def edges(self) -> List["Edge"]:
-        return self._e
-
-    def add_vertex(self, vertex: "Vertex"):
-        self._v.add(vertex)
-
-    def add_edge(self, edge: "Edge"):
-        self._e.add(edge)
-
-        edge.head._add_incidence(edge)
-        edge.tail._add_incidence(edge)
-
-    def find_edge(self, u: "Vertex", v: "Vertex") -> List["Edge"]:
-        left = u._incidence.get(v, None)
-        right = None
-
-        if not self._directed:
-            right = v._incidence.get(u, None)
-
-        if left is None and right is None:
-            return set()
-
-        if left is None:
-            return right
-
-        if right is None:
-            return left
-
-        return left | right
-
-    def is_adjacent(self, u: "Vertex", v: "Vertex") -> bool:
-        return v in u._incidence or (not self._directed and u in v._incidence)

--- a/mygraph.py
+++ b/mygraph.py
@@ -37,8 +37,9 @@ class Vertex(object):
         :param graph: The graph that this `Vertex` is a part of
         :param label: Optional parameter to specify a label for the
         """
+
         if label is None:
-            label = graph._next_label()
+            label = Graph.next_label()
 
         self._graph = graph
         self.label = label
@@ -197,6 +198,26 @@ class Edge(object):
 
 
 class Graph(object):
+    _generated_label_values = set()
+    _next_label_value = 0
+
+    @staticmethod
+    def next_label() -> int:
+        """Generate a unique label.
+
+        :return: A unique label.
+        """
+
+        next_label_value = Graph._next_label_value
+
+        while next_label_value in Graph._generated_label_values:
+            next_label_value += 1
+
+        Graph._generated_label_values.add(next_label_value)
+        Graph._next_label_value = next_label_value + 1
+
+        return next_label_value
+
     def __init__(self, directed: bool = False, n: int = 0, simple: bool = False):
         """
         Creates a graph.
@@ -208,7 +229,6 @@ class Graph(object):
         self._e = list()
         self._simple = simple
         self._directed = directed
-        self._next_label_value = 0
         self._tag = None
 
         for i in range(n):
@@ -252,15 +272,6 @@ class Graph(object):
         if isinstance(self, other.__class__):
             return self.__dict__ == other.__dict__
         return NotImplemented
-
-    def _next_label(self) -> int:
-        """
-        Generates unique labels for vertices within the graph
-        :return: A unique label
-        """
-        result = self._next_label_value
-        self._next_label_value += 1
-        return result
 
     @property
     def simple(self) -> bool:

--- a/mygraph.py
+++ b/mygraph.py
@@ -209,6 +209,7 @@ class Graph(object):
         self._simple = simple
         self._directed = directed
         self._next_label_value = 0
+        self._tag = None
 
         for i in range(n):
             self.add_vertex(Vertex(self))
@@ -218,7 +219,18 @@ class Graph(object):
         A programmer-friendly representation of the Graph.
         :return: The string to approximate the constructor arguments of the `Graph'
         """
-        return 'Graph(directed={}, simple={}, #edges={n_edges}, #vertices={n_vertices})'.format(
+
+        tag_string = ''
+        if self._tag is not None:
+            tag_string = f'tag="{self._tag}", '
+
+        return \
+            'Graph(' \
+            + tag_string + \
+            'directed={}, ' \
+            'simple={}, ' \
+            '#edges={n_edges}, ' \
+            '#vertices={n_vertices})'.format(
             self._directed, self._simple, n_edges=len(self._e), n_vertices=len(self._v))
 
     def __str__(self) -> str:
@@ -226,7 +238,15 @@ class Graph(object):
         A user-friendly representation of this graph
         :return: A textual representation of the vertices and edges of this graph
         """
-        return 'V=[' + ", ".join(map(str, self._v)) + ']\nE=[' + ", ".join(map(str, self._e)) + ']'
+
+        tag_string = ''
+        if self._tag is not None:
+            tag_string = f'"{self._tag}"\n'
+
+        return \
+            tag_string + \
+            'V=[{0}]\n' \
+            'E=[{1}]'.format(", ".join(map(str, self._v)), ", ".join(map(str, self._e)))
 
     def __eq__(self, other):
         if isinstance(self, other.__class__):
@@ -271,6 +291,14 @@ class Graph(object):
         :return: The `set` of edges of the graph
         """
         return list(self._e)
+
+    @property
+    def tag(self):
+        return self._tag
+
+    @tag.setter
+    def tag(self, tag):
+        self._tag = tag
 
     def __iter__(self):
         """

--- a/mygraph.py
+++ b/mygraph.py
@@ -281,16 +281,16 @@ class Graph(object):
     @property
     def vertices(self) -> List["Vertex"]:
         """
-        :return: The `set` of vertices of the graph
+        :return: The `list` of vertices of the graph
         """
-        return list(self._v)
+        return self._v
 
     @property
     def edges(self) -> List["Edge"]:
         """
-        :return: The `set` of edges of the graph
+        :return: The `list` of edges of the graph
         """
-        return list(self._e)
+        return self._e
 
     @property
     def tag(self):
@@ -326,7 +326,6 @@ class Graph(object):
         for e in vertex.incidence:
             self.del_edge(e)
         self._v.remove(vertex)
-
 
     def add_edge(self, edge: "Edge"):
         """

--- a/mygraph.py
+++ b/mygraph.py
@@ -197,7 +197,7 @@ class Edge(object):
 
 
 class Graph(object):
-    def __init__(self, directed: bool, n: int=0, simple: bool=False):
+    def __init__(self, directed: bool = False, n: int = 0, simple: bool = False):
         """
         Creates a graph.
         :param directed: Whether the graph should behave as a directed graph.

--- a/mygraph.py
+++ b/mygraph.py
@@ -365,20 +365,32 @@ class Graph(Hashable):
         edge.tail.incidence.remove(edge)
 
     def __add__(self, other: "Graph") -> "Graph":
-        """
-        Make a disjoint union of two graphs.
-        :param other: Graph to add to `self'.
-        :return: New graph which is a disjoint union of `self' and `other'.
-        """
-        # TODO: implementation
-        pass
+        """Make a disjoint union of two graphs.
 
-    def __iadd__(self, other: Union[Edge, Vertex]) -> "Graph":
+        :param Graph other: Graph to add to `self'.
+        :return: New graph object which is a disjoint union of `self' and `other'.
         """
-        Add either an `Edge` or `Vertex` with the += syntax.
-        :param other: The object to be added
-        :return: The modified graph
+
+        graph = Graph(n=0, simple=self.simple or other.simple, directed=self.directed or other.directed)
+
+        for vertex in self.vertices + other.vertices:
+            graph.add_vertex(vertex)
+
+        for edge in self.edges + other.edges:
+            graph.add_edge(edge)
+
+        return graph
+
+    def __iadd__(self, other: Union['Graph', Vertex, Edge]) -> "Graph":
+        """Add a `Graph`, `Vertex` or `Edge` with the += operator.
+
+        :param other: The object to be added.
+        :return: The modified graph.
         """
+
+        if isinstance(self, other.__class__):
+            return self + other
+
         if isinstance(other, Vertex):
             self.add_vertex(other)
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -7,6 +7,10 @@ from mygraph import Graph, Edge
 class Tests(unittest.TestCase):
 
     def setUp(self):
+        # Prepare some vertex labels for general use
+        vertex_labels = ['spam', 'ham', 'eggs', 'foo', 'bar', 'baz', 'qux', 'quux', 'quuz', 'corge', 'grault', 'garply',
+                         'waldo', 'fred', 'plugh', 'xyzzy', 'thud']
+
         # Instantiate the empty graph
         empty_graph = Graph()
         # empty_graph.tag = 'empty_graph'  # Don't uncomment
@@ -17,6 +21,8 @@ class Tests(unittest.TestCase):
         vertices = connected_graph_order_2.vertices
         connected_graph_order_2.add_edge(Edge(tail=vertices[0], head=vertices[1]))
         connected_graph_order_2.tag = 'connected_graph_order_2'
+        for (vertex, label) in zip(connected_graph_order_2.vertices, vertex_labels):
+            vertex.label = label
         self.connected_graph_order_2 = connected_graph_order_2
 
         # Instantiate the disconnected graph of order 2, which is the complement of a connected graph of order 2
@@ -73,6 +79,14 @@ class Tests(unittest.TestCase):
         # are unequal
         self.assertNotEqual(self.non_trivial_graph, self.non_trivial_graph_different_label)
         self.assertNotEqual(self.non_trivial_graph, self.non_trivial_graph_different_weight)
+
+    def test_mygraph_graph_next_label(self):
+        generated_max = max(Graph._generated_label_values, default=0)
+        Graph._generated_label_values |= set(range(0, 2 * generated_max))
+        self.assertEqual(2 * generated_max, Graph.next_label())
+        self.assertEqual(2 * generated_max + 1, Graph._next_label_value)
+        self.assertEqual(Graph._next_label_value, Graph.next_label())
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,7 +1,7 @@
 import unittest
 from copy import deepcopy
 
-from mygraph import Graph, Edge
+from mygraph import Graph, Edge, Vertex
 
 
 class Tests(unittest.TestCase):
@@ -53,6 +53,22 @@ class Tests(unittest.TestCase):
         non_trivial_graph_different_weight.add_edge(Edge(tail=edge.tail, head=edge.head, weight=1))
         non_trivial_graph_different_weight.tag = 'non_trivial_graph_different_weight'
         self.non_trivial_graph_different_weight = non_trivial_graph_different_weight
+
+    def test_mygraph_vertex_graphs(self):
+        vertex = Vertex()
+
+        self.assertEqual(set(), vertex.graphs)
+
+        self.non_trivial_graph.add_vertex(vertex)
+        self.assertTrue(self.non_trivial_graph in vertex.graphs)
+
+        self.connected_graph_order_2.add_vertex(vertex)
+        self.assertTrue(self.connected_graph_order_2 in vertex.graphs)
+        self.assertTrue(self.non_trivial_graph in vertex.graphs)
+
+        self.non_trivial_graph.del_vertex(vertex)
+        self.assertFalse(self.non_trivial_graph in vertex.graphs)
+        self.assertTrue(self.connected_graph_order_2 in vertex.graphs)
 
     def test_mygraph_graph_tag(self):
         graph = Graph()

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -8,13 +8,21 @@ class Tests(unittest.TestCase):
 
     def setUp(self):
         # Instantiate the empty graph
-        self.empty_graph = Graph()
+        empty_graph = Graph()
+        # empty_graph.tag = 'empty_graph'  # Don't uncomment
+        self.empty_graph = empty_graph
 
         # Instantiate a connected graph of order 2
         connected_graph_order_2 = Graph(n=2)
         vertices = connected_graph_order_2.vertices
         connected_graph_order_2.add_edge(Edge(tail=vertices[0], head=vertices[1]))
+        connected_graph_order_2.tag = 'connected_graph_order_2'
         self.connected_graph_order_2 = connected_graph_order_2
+
+        # Instantiate the disconnected graph of order 2, which is the complement of a connected graph of order 2
+        disconnected_graph_order_2 = Graph(n=2)
+        # disconnected_graph_order_2 = 'disconnected_graph_order_2'  # Don't uncomment
+        self.disconnected_graph_order_2 = disconnected_graph_order_2
 
         # Instantiate a non-trivial graph
         non_trivial_graph = Graph(n=5)
@@ -24,18 +32,27 @@ class Tests(unittest.TestCase):
         non_trivial_graph.add_edge(Edge(vertices[1], vertices[4]))
         non_trivial_graph.add_edge(Edge(vertices[2], vertices[3]))
         non_trivial_graph.add_edge(Edge(vertices[3], vertices[4]))
+        non_trivial_graph.tag = 'non_trivial_graph'
         self.non_trivial_graph = non_trivial_graph
 
         # Create two instances of the same non-trivial graph, each with one different sub-element field
         non_trivial_graph_different_label = deepcopy(self.non_trivial_graph)
         non_trivial_graph_different_label.vertices[0].label = 'spam'
+        non_trivial_graph_different_label.tag = 'non_trivial_graph_different_label'
         self.non_trivial_graph_different_label = non_trivial_graph_different_label
 
         non_trivial_graph_different_weight = deepcopy(self.non_trivial_graph)
         edge = non_trivial_graph_different_weight.edges[0]
         non_trivial_graph_different_weight.del_edge(edge)
         non_trivial_graph_different_weight.add_edge(Edge(tail=edge.tail, head=edge.head, weight=1))
+        non_trivial_graph_different_weight.tag = 'non_trivial_graph_different_weight'
         self.non_trivial_graph_different_weight = non_trivial_graph_different_weight
+
+    def test_mygraph_graph_tag(self):
+        graph = Graph()
+        self.assertEqual(None, graph.tag)
+        graph.tag = 'spam'
+        self.assertEqual('spam', graph.tag)
 
     def test_mygraph_graph_eq(self):
         # Assert that a graph is not an object of a different type
@@ -43,7 +60,11 @@ class Tests(unittest.TestCase):
 
         # Assert that the empty graph is equal to itself
         self.assertEqual(self.empty_graph, self.empty_graph)
-        self.assertEqual(Graph(), self.empty_graph)
+
+        # Assert that the tagless empty graph is unequal to the empty graph with a tag
+        graph = Graph()
+        graph.tag = 'spam'
+        self.assertNotEqual(self.empty_graph, graph)
 
         # Assert that a non-trivial graph is equal to itself
         self.assertEqual(self.non_trivial_graph, self.non_trivial_graph)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,57 @@
+import unittest
+from copy import deepcopy
+
+from mygraph import Graph, Edge
+
+
+class Tests(unittest.TestCase):
+
+    def setUp(self):
+        # Instantiate the empty graph
+        self.empty_graph = Graph()
+
+        # Instantiate a connected graph of order 2
+        connected_graph_order_2 = Graph(n=2)
+        vertices = connected_graph_order_2.vertices
+        connected_graph_order_2.add_edge(Edge(tail=vertices[0], head=vertices[1]))
+        self.connected_graph_order_2 = connected_graph_order_2
+
+        # Instantiate a non-trivial graph
+        non_trivial_graph = Graph(n=5)
+        vertices = non_trivial_graph.vertices
+        non_trivial_graph.add_edge(Edge(vertices[0], vertices[1]))
+        non_trivial_graph.add_edge(Edge(vertices[1], vertices[2]))
+        non_trivial_graph.add_edge(Edge(vertices[1], vertices[4]))
+        non_trivial_graph.add_edge(Edge(vertices[2], vertices[3]))
+        non_trivial_graph.add_edge(Edge(vertices[3], vertices[4]))
+        self.non_trivial_graph = non_trivial_graph
+
+        # Create two instances of the same non-trivial graph, each with one different sub-element field
+        non_trivial_graph_different_label = deepcopy(self.non_trivial_graph)
+        non_trivial_graph_different_label.vertices[0].label = 'spam'
+        self.non_trivial_graph_different_label = non_trivial_graph_different_label
+
+        non_trivial_graph_different_weight = deepcopy(self.non_trivial_graph)
+        edge = non_trivial_graph_different_weight.edges[0]
+        non_trivial_graph_different_weight.del_edge(edge)
+        non_trivial_graph_different_weight.add_edge(Edge(tail=edge.tail, head=edge.head, weight=1))
+        self.non_trivial_graph_different_weight = non_trivial_graph_different_weight
+
+    def test_mygraph_graph_eq(self):
+        # Assert that a graph is not an object of a different type
+        self.assertNotEqual(None, Graph())
+
+        # Assert that the empty graph is equal to itself
+        self.assertEqual(self.empty_graph, self.empty_graph)
+        self.assertEqual(Graph(), self.empty_graph)
+
+        # Assert that a non-trivial graph is equal to itself
+        self.assertEqual(self.non_trivial_graph, self.non_trivial_graph)
+
+        # Assert that a non-trivial graph and others with the same structure but with different sub-element fields
+        # are unequal
+        self.assertNotEqual(self.non_trivial_graph, self.non_trivial_graph_different_label)
+        self.assertNotEqual(self.non_trivial_graph, self.non_trivial_graph_different_weight)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -96,6 +96,29 @@ class Tests(unittest.TestCase):
         self.assertNotEqual(self.non_trivial_graph, self.non_trivial_graph_different_label)
         self.assertNotEqual(self.non_trivial_graph, self.non_trivial_graph_different_weight)
 
+    def test_mygraph_graph_add(self):
+        # Assert that the empty graph added to itself is itself
+        self.assertEqual(self.empty_graph, self.empty_graph + self.empty_graph)
+
+        # Assert that adding the empty graph to a non-empty graph is the non-empty graph
+        self.non_trivial_graph.tag = Graph().tag  # Get the default graph tag
+
+        self.assertEqual(self.non_trivial_graph, self.non_trivial_graph + self.empty_graph)
+        self.assertEqual(self.non_trivial_graph, self.empty_graph + self.non_trivial_graph)
+
+        # Assert that all vertices and edges of two individual non-empty graphs are in their disjoint union
+        disjoint_union = self.non_trivial_graph + self.connected_graph_order_2
+        expected_vertices = self.non_trivial_graph.vertices + self.connected_graph_order_2.vertices
+        expected_edges = self.non_trivial_graph.edges + self.connected_graph_order_2.edges
+        self.assertEqual(expected_vertices, disjoint_union.vertices)
+        self.assertEqual(expected_edges, disjoint_union.edges)
+
+        # Assert the same, but use the inline addition operator
+        self.non_trivial_graph += self.connected_graph_order_2
+        self.assertEqual(expected_vertices, self.non_trivial_graph.vertices)
+        self.assertEqual(expected_edges, self.non_trivial_graph.edges)
+
+
     def test_mygraph_graph_next_label(self):
         generated_max = max(Graph._generated_label_values, default=0)
         Graph._generated_label_values |= set(range(0, 2 * generated_max))


### PR DESCRIPTION
My proposal for enhancements of `class Graph`. Some of these changes are required for future features like testing graph object equality and calculation of the complement (#3).

There's probably loads of conflicts with your (@dorienmc @ClaudiaReuvers) changes, but that's what this PR is for: to sort them out, fix them!

Changes / additions:
 - `Graph` now is `Hashable`.
 - `Vertex.__init__` does not have a `graph: Graph` parameter anymore.
 - `Graph._next_label` has been renamed and now is static.
   - It also incorporates a basic system to generate unique labels.
 - `Vertex` now has a property `graphs` (shadowing `_graphs`), a set of `Graph`. For this, `Graph` must be `Hashable`.
   - When a vertex is added to a graph, the graph is added to the vertex' set of graphs.
   - When a vertex is removed from a graph, the graph is removed from the vertex' set of graphs.
 - `Graph.__init__` now doesn't require parameter `directed`; it now is optional and defaults to `False`.
 - `Graph` now has a `tag` property (shadowing `_tag`), by default `None`, but it can be anything.
   - `Graph.__str__` prints the tag if not `None`.
   - `Graph.__repr__` prints the tag if not `None`.
 - `Graph` now implements `__eq__` to be able to compare graphs using the `==` comparator.
 - Two graph objects now can be added to form a new graph objects forming their disjoint union with the `+` (addition) and `+=` (inline addition) operators.
 - The `UnsafeGraph` class has been removed.
 - Most things are tested. **Please think about incorrect or additional testing to perform!**
 - Some code has been optimised.
 - Many documentation additions, changes and enhancements.