### PR TITLE
Keep track of known isomorphisms

### DIFF
--- a/color_refinement.py
+++ b/color_refinement.py
@@ -13,7 +13,6 @@ PATH = './graphs/branching/'
 GRAPH = 'cubes5.grl'
 
 known_isomorphisms: Dict[int, Set[int]] = {}
-known_anisomorphisms: Dict[int, Set[int]] = {}
 
 
 def count_isomorphism(g: Graph, h: Graph, coloring: Coloring, count: bool = True) -> int:
@@ -240,27 +239,13 @@ def store_isomorphism(i: int, j: int, known_isomorphisms: Dict[int, Set[int]]):
         known_isomorphisms[index] = isomorphisms - {index}
 
 
-def store_anisomorphism(i: int, j: int, known_anisomorphisms: Dict[int, Set[int]]):
-    """
-    Store a known isomorphism between two indices in the specified mapping.
-
-    :param int i: Index of one known anisomorphism pair member.
-    :param int j: Index of another known anisomorphism pair member.
-    :param dict known_anisomorphisms: Dictionary in which to store the set of known anisomorphisms.
-    """
-
-    known_anisomorphisms[i] = known_anisomorphisms[i] | {j}
-    known_anisomorphisms[j] = known_anisomorphisms[j] | {i}
-
-
 def process(graphs: List[Graph]):
-    global known_isomorphisms, known_anisomorphisms
+    global known_isomorphisms
 
     graph_indices = range(len(graphs))
 
-    # Note: trivial automorphisms are never stored in the following collections
+    # Note: trivial automorphisms are never stored
     known_isomorphisms = {}.fromkeys(graph_indices, set())
-    known_anisomorphisms = dict(known_isomorphisms)
 
     for i in graph_indices:
         for j in graph_indices:
@@ -270,10 +255,13 @@ def process(graphs: List[Graph]):
                 end = time.time()
 
                 print('There are', num, 'automorphisms of', graphs[i].name)
-                print('Took', end - start, 'seconds\n')
+                print('Took', end - start, 'seconds')
 
             if j > i:
-                if j not in known_isomorphisms[i] and j not in known_anisomorphisms[i]:
+                if j in known_isomorphisms[i]:
+                    print(graphs[i].name, 'and', graphs[j].name, 'are already known to be isomorphic')
+
+                else:
                     start = time.time()
                     isomorphism = is_isomorphisms(graphs[i], graphs[j])
 
@@ -283,25 +271,14 @@ def process(graphs: List[Graph]):
 
                     end = time.time()
 
-                    if isomorphism:
-                        store_isomorphism(i, j, known_isomorphisms)
-                    else:
-                        store_anisomorphism(i, j, known_anisomorphisms)
-
                     print(graphs[i].name, 'and', graphs[j].name, 'isomorphic?', isomorphism)
 
                     if isomorphism:
+                        store_isomorphism(i, j, known_isomorphisms)
                         print('There are', num, 'isomorphisms')
 
-                    print('Took', end - start, 'seconds\n')
-
-                else:
-                    isomorphism_status_string = 'isomorphic'
-                    if j in known_anisomorphisms[i]:
-                        isomorphism_status_string = 'an' + isomorphism_status_string
-
-                    print(graphs[i].name, 'and', graphs[j].name, 'are already known to be', isomorphism_status_string)
-                    print()
+                    print('Took', end - start, 'seconds')
+            print()
 
 
 if __name__ == "__main__":

--- a/color_refinement.py
+++ b/color_refinement.py
@@ -9,10 +9,10 @@ import preprocessing
 from color_refinement_helper import *
 from graph_io import *
 
-PATH = './graphs/branching/'
+PATH = 'graphs/branching/'
 GRAPH = 'cubes5.grl'
 
-known_isomorphisms: Dict[int, Set[int]] = {}
+IsomorphismMapping = Dict[int, Set[int]]
 
 
 def count_isomorphism(g: Graph, h: Graph, coloring: Coloring, count: bool = True) -> int:
@@ -239,13 +239,18 @@ def store_isomorphism(i: int, j: int, known_isomorphisms: Dict[int, Set[int]]):
         known_isomorphisms[index] = isomorphisms - {index}
 
 
-def process(graphs: List[Graph]):
-    global known_isomorphisms
+def process(graphs: List[Graph]) -> IsomorphismMapping:
+    """
+    Process a list of graphs to find indices into that list of isomorphic graphs.
+
+    :param list graphs: The list of graphs to process.
+    :return: An `IsomorphismMapping`, which is a mapping of graph indices to sets of isomorphic graph indices.
+    """
 
     graph_indices = range(len(graphs))
 
     # Note: trivial automorphisms are never stored
-    known_isomorphisms = {}.fromkeys(graph_indices, set())
+    isomorphism_index_mapping = {}.fromkeys(graph_indices, set())
 
     for i in graph_indices:
         for j in graph_indices:
@@ -258,7 +263,7 @@ def process(graphs: List[Graph]):
                 print('Took', end - start, 'seconds')
 
             if j > i:
-                if j in known_isomorphisms[i]:
+                if j in isomorphism_index_mapping[i]:
                     print(graphs[i].name, 'and', graphs[j].name, 'are already known to be isomorphic')
 
                 else:
@@ -274,11 +279,13 @@ def process(graphs: List[Graph]):
                     print(graphs[i].name, 'and', graphs[j].name, 'isomorphic?', isomorphism)
 
                     if isomorphism:
-                        store_isomorphism(i, j, known_isomorphisms)
+                        store_isomorphism(i, j, isomorphism_index_mapping)
                         print('There are', num, 'isomorphisms')
 
                     print('Took', end - start, 'seconds')
             print()
+
+    return isomorphism_index_mapping
 
 
 if __name__ == "__main__":
@@ -288,4 +295,4 @@ if __name__ == "__main__":
     graphs = L[0]
     print("Graph: ", GRAPH)
 
-    process(graphs)
+    known_isomorphisms = process(graphs)

--- a/color_refinement.py
+++ b/color_refinement.py
@@ -3,11 +3,11 @@ This is a module for the color refinement algorithm
 version: 20-3-18, Claudia Reuvers & Dorien Meijer Cluwen
 """
 import time
+from typing import Dict
 
 import preprocessing
 from color_refinement_helper import *
 from graph_io import *
-from tools import store_morphism
 
 PATH = './graphs/branching/'
 GRAPH = 'cubes5.grl'
@@ -217,6 +217,39 @@ def get_number_automorphisms(g: Graph) -> int:
     return get_number_isomorphisms(g, g.deepcopy(), True)
 
 
+def store_isomorphism(i: int, j: int, known_isomorphisms: Dict[int, Set[int]]):
+    """
+    Store a known isomorphism between two indices in the specified mapping.
+
+    :param int i: Index of one known isomorphism pair member.
+    :param int j: Index of another known isomorphism pair member.
+    :param dict known_isomorphisms: Dictionary in which to store the set of known isomorphisms.
+    """
+
+    isomorphisms = set()
+
+    for index in (i, j):
+        isomorphisms |= known_isomorphisms[index]
+
+    isomorphisms |= {i, j}
+
+    for index in isomorphisms:
+        known_isomorphisms[index] = isomorphisms - {index}
+
+
+def store_anisomorphism(i: int, j: int, known_anisomorphisms: Dict[int, Set[int]]):
+    """
+    Store a known isomorphism between two indices in the specified mapping.
+
+    :param int i: Index of one known anisomorphism pair member.
+    :param int j: Index of another known anisomorphism pair member.
+    :param dict known_anisomorphisms: Dictionary in which to store the set of known anisomorphisms.
+    """
+
+    known_anisomorphisms[i] = known_anisomorphisms[i] | {j}
+    known_anisomorphisms[j] = known_anisomorphisms[j] | {i}
+
+
 if __name__ == "__main__":
     with open(PATH + GRAPH) as f:
         L = load_graph(f, read_list=True)
@@ -252,9 +285,9 @@ if __name__ == "__main__":
                     end = time.time()
 
                     if isomorphism:
-                        store_morphism(i, j, known_isomorphisms)
+                        store_isomorphism(i, j, known_isomorphisms)
                     else:
-                        store_morphism(i, j, known_anisomorphisms)
+                        store_anisomorphism(i, j, known_anisomorphisms)
 
                     print(graphs[i].name, 'and', graphs[j].name, 'isomorphic?', isomorphism)
 

--- a/color_refinement.py
+++ b/color_refinement.py
@@ -12,6 +12,9 @@ from graph_io import *
 PATH = './graphs/branching/'
 GRAPH = 'cubes5.grl'
 
+known_isomorphisms: Dict[int, Set[int]] = {}
+known_anisomorphisms: Dict[int, Set[int]] = {}
+
 
 def count_isomorphism(g: Graph, h: Graph, coloring: Coloring, count: bool = True) -> int:
     """
@@ -250,12 +253,8 @@ def store_anisomorphism(i: int, j: int, known_anisomorphisms: Dict[int, Set[int]
     known_anisomorphisms[j] = known_anisomorphisms[j] | {i}
 
 
-if __name__ == "__main__":
-    with open(PATH + GRAPH) as f:
-        L = load_graph(f, read_list=True)
-
-    graphs = L[0]
-    print("Graph: ", GRAPH)
+def process(graphs: List[Graph]):
+    global known_isomorphisms, known_anisomorphisms
 
     graph_indices = range(len(graphs))
 
@@ -303,3 +302,13 @@ if __name__ == "__main__":
 
                     print(graphs[i].name, 'and', graphs[j].name, 'are already known to be', isomorphism_status_string)
                     print()
+
+
+if __name__ == "__main__":
+    with open(PATH + GRAPH) as f:
+        L = load_graph(f, read_list=True)
+
+    graphs = L[0]
+    print("Graph: ", GRAPH)
+
+    process(graphs)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,9 +1,6 @@
 from typing import Tuple
 
-import tests
-from graph import *
 from coloring import *
-from graph import *
 
 # Declare module variables
 empty_graph: Graph
@@ -13,11 +10,14 @@ non_trivial_graph: Graph
 non_trivial_graph_different_label: Graph
 non_trivial_graph_different_weight: Graph
 non_trivial_graph_complement: Graph
+isomorphic_graphs: List[Graph]
+anisomorphic_graphs: List[Graph]
 
 
 def set_up_test_graphs():
     global empty_graph, connected_graph_order_2, disconnected_graph_order_2, non_trivial_graph, \
-        non_trivial_graph_different_label, non_trivial_graph_different_weight, non_trivial_graph_complement
+        non_trivial_graph_different_label, non_trivial_graph_different_weight, non_trivial_graph_complement, \
+        isomorphic_graphs, anisomorphic_graphs
 
     # Prepare some vertex labels for general use
     vertex_labels = ['spam', 'ham', 'eggs', 'foo', 'bar', 'baz', 'qux', 'quux', 'quuz', 'corge', 'grault', 'garply',
@@ -39,6 +39,7 @@ def set_up_test_graphs():
     #          \ /
     #           4
     non_trivial_graph = create_graph_helper([(0, 1), (1, 2), (1, 4), (2, 3), (3, 4)])
+    non_trivial_graph.name = 'non_trivial_graph'
 
     # Instantiate the non-trivial graph's complement
     # non_trivial_graph_complement =
@@ -46,6 +47,29 @@ def set_up_test_graphs():
     #              / \
     #     1 - 3 - 0 - 4
     non_trivial_graph_complement = create_graph_helper([(2, 0), (3, 0), (4, 0), (3, 1), (4, 2)])
+    non_trivial_graph_complement.name = 'non_trivial_graph_complement'
+
+    # Instantiate some isomorphic graphs
+    # non_trivial_graph_isomorphism =
+    #           4
+    #          / \
+    #     0 - 1   3
+    #          \ /
+    #           2
+    non_trivial_graph_isomorphism = create_graph_helper([(0, 1), (1, 2), (2, 3), (3, 4), (1, 4)])
+    non_trivial_graph_isomorphism.name = 'non_trivial_graph_isomorphism'
+
+    isomorphic_graphs = [non_trivial_graph, non_trivial_graph_isomorphism]
+
+    # Instantiate some anisomorphic graphs
+    # another_non_trivial_graph =
+    #  1 - 2 - 3 - 4
+    #       \ /
+    #        0
+    another_non_trivial_graph = create_graph_helper([(1, 2), (0, 2), (2, 3), (0, 3), (3, 4)])
+    another_non_trivial_graph.name = 'another_non_trivial_graph'
+
+    anisomorphic_graphs = [non_trivial_graph_complement, another_non_trivial_graph]
 
 
 def create_graph_helper(edges: List[Tuple[object, object]] = list()):
@@ -195,4 +219,3 @@ def graph_vertex5edge4loop() -> Graph:
     v5e4loop.add_edge(e_h3)
     v5e4loop.add_edge(e_h4)
     return v5e4loop
-

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -50,26 +50,53 @@ def set_up_test_graphs():
     non_trivial_graph_complement.name = 'non_trivial_graph_complement'
 
     # Instantiate some isomorphic graphs
-    # non_trivial_graph_isomorphism =
-    #           4
-    #          / \
-    #     0 - 1   3
-    #          \ /
-    #           2
-    non_trivial_graph_isomorphism = create_graph_helper([(0, 1), (1, 2), (2, 3), (3, 4), (1, 4)])
-    non_trivial_graph_isomorphism.name = 'non_trivial_graph_isomorphism'
-
-    isomorphic_graphs = [non_trivial_graph, non_trivial_graph_isomorphism]
+    # iso_0 =
+    #           - 0 -
+    #          /     \
+    #     3 - 4 - 1 - 5
+    #          \     /
+    #           - 2 -
+    # iso_1 =
+    #           - 2 -
+    #          /     \
+    #     3 - 4 - 0 - 5
+    #          \     /
+    #           - 1 -
+    # iso_2 =
+    #           - 1 -
+    #          /     \
+    #     3 - 4 - 2 - 5
+    #          \     /
+    #           - 0 -
+    changing_labels = [0, 1, 2]
+    isomorphic_graphs = []
+    for _ in range(len(changing_labels)):  # Because changing_labels changes, this can't simply be changing_labels
+        _0 = changing_labels[0]
+        _1 = changing_labels[1]
+        _2 = changing_labels[2]
+        isomorphism = create_graph_helper([(3, 4), (4, _0), (_0, 5), (4, _1), (_1, 5), (4, _2), (_2, 5)])
+        isomorphism.name = f'isomorphism_{_0}_{_1}_{_2}'
+        isomorphic_graphs.append(isomorphism)
+        changing_labels = [changing_labels.pop()] + changing_labels
 
     # Instantiate some anisomorphic graphs
-    # another_non_trivial_graph =
-    #  1 - 2 - 3 - 4
-    #       \ /
-    #        0
-    another_non_trivial_graph = create_graph_helper([(1, 2), (0, 2), (2, 3), (0, 3), (3, 4)])
-    another_non_trivial_graph.name = 'another_non_trivial_graph'
-
-    anisomorphic_graphs = [non_trivial_graph_complement, another_non_trivial_graph]
+    # anisomorphism_0 =
+    #           - 4 -
+    #          /  |  \
+    #     3 - 0   1   2
+    #          \  |  /
+    #           - 5 -
+    # anisomorphism_1 =
+    #           - 4 -
+    #          /  |  \
+    #     3 - 0 - 1   2
+    #          \     /
+    #           - 5 -
+    anisomorphism_0 = create_graph_helper([(3, 0), (0, 4), (4, 1), (4, 2), (0, 5), (1, 5), (2, 5)])
+    anisomorphism_0.name = 'anisomorphism_0'
+    anisomorphism_1 = create_graph_helper([(3, 0), (0, 4), (4, 1), (4, 2), (0, 5), (1, 0), (2, 5)])
+    anisomorphism_1.name = 'anisomorphism_1'
+    anisomorphic_graphs = [anisomorphism_0, anisomorphism_1]
 
 
 def create_graph_helper(edges: List[Tuple[object, object]] = list()):

--- a/tests/integration/test_fast_color_refine.py
+++ b/tests/integration/test_fast_color_refine.py
@@ -70,10 +70,11 @@ class FastColorRefineCase(unittest.TestCase):
         graphs = tests.isomorphic_graphs + tests.anisomorphic_graphs
         color_refinement.process(graphs)
 
-        self.assertEqual({1}, color_refinement.known_isomorphisms[0])
-        self.assertEqual({0}, color_refinement.known_isomorphisms[1])
-        self.assertEqual(set(), color_refinement.known_isomorphisms[2])
+        self.assertEqual({1, 2}, color_refinement.known_isomorphisms[0])
+        self.assertEqual({0, 2}, color_refinement.known_isomorphisms[1])
+        self.assertEqual({0, 1}, color_refinement.known_isomorphisms[2])
         self.assertEqual(set(), color_refinement.known_isomorphisms[3])
+        self.assertEqual(set(), color_refinement.known_isomorphisms[4])
 
 
 if __name__ == '__main__':

--- a/tests/integration/test_fast_color_refine.py
+++ b/tests/integration/test_fast_color_refine.py
@@ -61,12 +61,11 @@ class FastColorRefineCase(unittest.TestCase):
                 color_refinement.debug(result[2], 'got', result[1])
 
     def test_storing_known_an_isomorphisms(self):
-        # Assert that initially there are no known (an)isomorphisms
+        # Assert that initially there are no known isomorphisms
         self.assertEqual({}, color_refinement.known_isomorphisms)
-        self.assertEqual({}, color_refinement.known_anisomorphisms)
 
         # Assert that, after processing a list of graphs containing some isomorphisms and anisomorphisms, the known
-        # (an)isomorphisms are correct
+        # isomorphisms are correct
         tests.set_up_test_graphs()
         graphs = tests.isomorphic_graphs + tests.anisomorphic_graphs
         color_refinement.process(graphs)
@@ -75,11 +74,6 @@ class FastColorRefineCase(unittest.TestCase):
         self.assertEqual({0}, color_refinement.known_isomorphisms[1])
         self.assertEqual(set(), color_refinement.known_isomorphisms[2])
         self.assertEqual(set(), color_refinement.known_isomorphisms[3])
-
-        self.assertEqual({2, 3}, color_refinement.known_anisomorphisms[0])
-        self.assertEqual({2, 3}, color_refinement.known_anisomorphisms[1])
-        self.assertEqual({0, 1, 3}, color_refinement.known_anisomorphisms[2])
-        self.assertEqual({0, 1, 2, }, color_refinement.known_anisomorphisms[3])
 
 
 if __name__ == '__main__':

--- a/tests/integration/test_fast_color_refine.py
+++ b/tests/integration/test_fast_color_refine.py
@@ -7,13 +7,13 @@ import unittest
 from color_refinement import fast_color_refine
 from color_refinement_helper import *
 from graph_io import *
-from tools import dot_to_pdf
 
-PATH = 'graphs/colorref'# to run locally from PyCharm: PATH = '../../graphs/colorref'
+PATH = 'graphs/colorref'
 EXPECTED = dict()
 EXPECTED['colorref_smallexample_2_49.grl'] = {'G0G1': "Bijection"}
 EXPECTED['colorref_smallexample_4_7.grl'] = {'G1G3': "Bijection", 'G0G2': None}
 EXPECTED['colorref_smallexample_6_15.grl'] = {'G0G1': "Bijection", 'G2G3': None, 'G4G5': None}
+
 
 def get_expected_result(filename, g_name, h_name):
     if filename in EXPECTED.keys():
@@ -23,9 +23,11 @@ def get_expected_result(filename, g_name, h_name):
         else:
             return "Unbalanced"
 
+
 def get_color_ref_files():
     all_graphs = os.listdir(PATH)
     return [x for x in all_graphs if x in EXPECTED.keys()]
+
 
 def testfile(filename):
     """Check if results for the given file are correct"""
@@ -46,6 +48,7 @@ def testfile(filename):
                 results.append([expected, status, message])
     return results
 
+
 class FastColorRefineCase(unittest.TestCase):
     """Tests for `color_refinement.py`."""
 
@@ -56,6 +59,7 @@ class FastColorRefineCase(unittest.TestCase):
             for result in results:
                 self.assertEqual(result[0], result[1], result[2])
                 debug(result[2], 'got', result[1])
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/integration/test_fast_color_refine.py
+++ b/tests/integration/test_fast_color_refine.py
@@ -4,8 +4,8 @@ Test file for Fast Color Refinement Algorithm
 import os
 import unittest
 
-import color_refinement
 import tests
+from color_refinement import process, debug, fast_color_refine, initialize_coloring
 from graph_io import *
 
 PATH = 'graphs/colorref'
@@ -25,13 +25,13 @@ def get_expected_result(filename, g_name, h_name):
 
 
 def get_color_ref_files():
-    all_graphs = os.listdir(color_refinement.PATH)
+    all_graphs = os.listdir(PATH)
     return [x for x in all_graphs if x in EXPECTED.keys()]
 
 
 def testfile(filename):
     """Check if results for the given file are correct"""
-    with open(color_refinement.PATH + "/" + filename) as f:
+    with open(PATH + "/" + filename) as f:
         L = load_graph(f, read_list=True)
 
     graphs = L[0]
@@ -39,8 +39,8 @@ def testfile(filename):
     for i in range(len(graphs)):
         for j in range(len(graphs)):
             if j > i:
-                coloring = color_refinement.initialize_coloring(graphs[i] + graphs[j])
-                coloring = color_refinement.fast_color_refine(coloring)
+                coloring = initialize_coloring(graphs[i] + graphs[j])
+                coloring = fast_color_refine(coloring)
                 status = coloring.status(graphs[i], graphs[j])
                 expected = get_expected_result(filename, graphs[i].name, graphs[j].name)
                 message = "Expected " + str(expected) + " for " + graphs[i].name + " and " + graphs[
@@ -58,23 +58,20 @@ class FastColorRefineCase(unittest.TestCase):
             results = testfile(file)
             for result in results:
                 self.assertEqual(result[0], result[1], result[2])
-                color_refinement.debug(result[2], 'got', result[1])
+                debug(result[2], 'got', result[1])
 
     def test_storing_known_isomorphisms(self):
-        # Assert that initially there are no known isomorphisms
-        self.assertEqual({}, color_refinement.known_isomorphisms)
-
         # Assert that, after processing a list of graphs containing some isomorphisms and anisomorphisms, the known
         # isomorphisms are correct
         tests.set_up_test_graphs()
         graphs = tests.isomorphic_graphs + tests.anisomorphic_graphs
-        color_refinement.process(graphs)
+        known_isomorphisms = process(graphs)
 
-        self.assertEqual({1, 2}, color_refinement.known_isomorphisms[0])
-        self.assertEqual({0, 2}, color_refinement.known_isomorphisms[1])
-        self.assertEqual({0, 1}, color_refinement.known_isomorphisms[2])
-        self.assertEqual(set(), color_refinement.known_isomorphisms[3])
-        self.assertEqual(set(), color_refinement.known_isomorphisms[4])
+        self.assertEqual({1, 2}, known_isomorphisms[0])
+        self.assertEqual({0, 2}, known_isomorphisms[1])
+        self.assertEqual({0, 1}, known_isomorphisms[2])
+        self.assertEqual(set(), known_isomorphisms[3])
+        self.assertEqual(set(), known_isomorphisms[4])
 
 
 if __name__ == '__main__':

--- a/tests/integration/test_fast_color_refine.py
+++ b/tests/integration/test_fast_color_refine.py
@@ -60,7 +60,7 @@ class FastColorRefineCase(unittest.TestCase):
                 self.assertEqual(result[0], result[1], result[2])
                 color_refinement.debug(result[2], 'got', result[1])
 
-    def test_storing_known_an_isomorphisms(self):
+    def test_storing_known_isomorphisms(self):
         # Assert that initially there are no known isomorphisms
         self.assertEqual({}, color_refinement.known_isomorphisms)
 

--- a/tests/unit/test_tools.py
+++ b/tests/unit/test_tools.py
@@ -41,30 +41,6 @@ class ToolsTests(unittest.TestCase):
         self.assertEqual({i, k}, known_isomorphisms[j])
         self.assertEqual({i, j}, known_isomorphisms[k])
 
-    def test_store_anisomorphism(self):
-        i = 0
-        j = 1
-        k = 2
-        known_anisomorphisms = {}.fromkeys([i, j, k], set())
-
-        # Assert that storing an anisomorphism results in a known mapping from i to j and from j to i
-        color_refinement.store_anisomorphism(i, j, known_anisomorphisms)
-        self.assertEqual({j}, known_anisomorphisms[i])
-        self.assertEqual({i}, known_anisomorphisms[j])
-        self.assertEqual(set(), known_anisomorphisms[k])
-
-        # Assert that storing the same anisomorphism twice changes nothing
-        color_refinement.store_anisomorphism(j, i, known_anisomorphisms)
-        self.assertEqual({j}, known_anisomorphisms[i])
-        self.assertEqual({i}, known_anisomorphisms[j])
-        self.assertEqual(set(), known_anisomorphisms[k])
-
-        # Assert that storing a new known anisomorphism only updates the indices involved, other indices are unchanged
-        color_refinement.store_anisomorphism(j, k, known_anisomorphisms)
-        self.assertEqual({j}, known_anisomorphisms[i])
-        self.assertEqual({i, k}, known_anisomorphisms[j])
-        self.assertEqual({j}, known_anisomorphisms[k])
-
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/unit/test_tools.py
+++ b/tests/unit/test_tools.py
@@ -15,6 +15,30 @@ class ToolsTests(unittest.TestCase):
         self.assertEqual(2 * generated_max + 1, unique_integer())
         self.assertEqual(tools._last_integer + 1, unique_integer())
 
+    def test_store_morphism(self):
+        i = 0
+        j = 1
+        known_isomorphisms = {}.fromkeys({i, j}, set())
+
+        tools.store_morphism(i, j, known_isomorphisms)
+
+        self.assertEqual({j}, known_isomorphisms[i])
+        self.assertEqual({i}, known_isomorphisms[j])
+
+        tools.store_morphism(i, j, known_isomorphisms)
+
+        self.assertEqual({j}, known_isomorphisms[i])
+        self.assertEqual({i}, known_isomorphisms[j])
+
+        i = 2
+        known_isomorphisms[2] = set()
+
+        tools.store_morphism(i, j, known_isomorphisms)
+
+        self.assertEqual({1, 2}, known_isomorphisms[0])
+        self.assertEqual({0, 2}, known_isomorphisms[1])
+        self.assertEqual({0, 1}, known_isomorphisms[2])
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/unit/test_tools.py
+++ b/tests/unit/test_tools.py
@@ -1,5 +1,6 @@
 import unittest
 
+import color_refinement
 import tools
 from tools import unique_integer
 
@@ -15,29 +16,54 @@ class ToolsTests(unittest.TestCase):
         self.assertEqual(2 * generated_max + 1, unique_integer())
         self.assertEqual(tools._last_integer + 1, unique_integer())
 
-    def test_store_morphism(self):
+    def test_store_isomorphism(self):
         i = 0
         j = 1
-        known_isomorphisms = {}.fromkeys({i, j}, set())
+        k = 2
+        known_isomorphisms = {}.fromkeys([i, j, k], set())
 
-        tools.store_morphism(i, j, known_isomorphisms)
+        # Assert that storing an isomorphism results in a known mapping from i to j and from j to i
+        color_refinement.store_isomorphism(i, j, known_isomorphisms)
+        self.assertEqual({j}, known_isomorphisms[i])
+        self.assertEqual({i}, known_isomorphisms[j])
+        self.assertEqual(set(), known_isomorphisms[k])
+
+        # Assert that storing the same isomorphism twice changes nothing
+        color_refinement.store_isomorphism(j, i, known_isomorphisms)
 
         self.assertEqual({j}, known_isomorphisms[i])
         self.assertEqual({i}, known_isomorphisms[j])
+        self.assertEqual(set(), known_isomorphisms[k])
 
-        tools.store_morphism(i, j, known_isomorphisms)
+        # Assert that storing a new known isomorphism updates all known isomorphism mappings
+        color_refinement.store_isomorphism(j, k, known_isomorphisms)
+        self.assertEqual({j, k}, known_isomorphisms[i])
+        self.assertEqual({i, k}, known_isomorphisms[j])
+        self.assertEqual({i, j}, known_isomorphisms[k])
 
-        self.assertEqual({j}, known_isomorphisms[i])
-        self.assertEqual({i}, known_isomorphisms[j])
+    def test_store_anisomorphism(self):
+        i = 0
+        j = 1
+        k = 2
+        known_anisomorphisms = {}.fromkeys([i, j, k], set())
 
-        i = 2
-        known_isomorphisms[2] = set()
+        # Assert that storing an anisomorphism results in a known mapping from i to j and from j to i
+        color_refinement.store_anisomorphism(i, j, known_anisomorphisms)
+        self.assertEqual({j}, known_anisomorphisms[i])
+        self.assertEqual({i}, known_anisomorphisms[j])
+        self.assertEqual(set(), known_anisomorphisms[k])
 
-        tools.store_morphism(i, j, known_isomorphisms)
+        # Assert that storing the same anisomorphism twice changes nothing
+        color_refinement.store_anisomorphism(j, i, known_anisomorphisms)
+        self.assertEqual({j}, known_anisomorphisms[i])
+        self.assertEqual({i}, known_anisomorphisms[j])
+        self.assertEqual(set(), known_anisomorphisms[k])
 
-        self.assertEqual({1, 2}, known_isomorphisms[0])
-        self.assertEqual({0, 2}, known_isomorphisms[1])
-        self.assertEqual({0, 1}, known_isomorphisms[2])
+        # Assert that storing a new known anisomorphism only updates the indices involved, other indices are unchanged
+        color_refinement.store_anisomorphism(j, k, known_anisomorphisms)
+        self.assertEqual({j}, known_anisomorphisms[i])
+        self.assertEqual({i, k}, known_anisomorphisms[j])
+        self.assertEqual({j}, known_anisomorphisms[k])
 
 
 if __name__ == '__main__':

--- a/tools/__init__.py
+++ b/tools/__init__.py
@@ -1,4 +1,5 @@
 import os
+from typing import Dict, Set
 
 _last_integer = 0
 _generated_integers = set()
@@ -31,3 +32,23 @@ def unique_integer() -> int:
 
     _generated_integers.add(_last_integer)
     return _last_integer
+
+
+def store_morphism(i: int, j: int, dict_of_pairs: Dict[int, Set[int]]):
+    """
+    Store a known morphism between two indices in the specified mapping.
+
+    :param int i: Index of one known morphism pair member.
+    :param int j: Index of another known morphism pair member.
+    :param dict dict_of_pairs: Dictionary in which to store the set of known morphisms.
+    """
+
+    morphisms = set()
+
+    for index in (i, j):
+        morphisms |= dict_of_pairs[index]
+
+    morphisms |= {i, j}
+
+    for index in morphisms:
+        dict_of_pairs[index] = morphisms - {index}

--- a/tools/__init__.py
+++ b/tools/__init__.py
@@ -1,5 +1,4 @@
 import os
-from typing import Dict, Set
 
 _last_integer = 0
 _generated_integers = set()
@@ -32,23 +31,3 @@ def unique_integer() -> int:
 
     _generated_integers.add(_last_integer)
     return _last_integer
-
-
-def store_morphism(i: int, j: int, dict_of_pairs: Dict[int, Set[int]]):
-    """
-    Store a known morphism between two indices in the specified mapping.
-
-    :param int i: Index of one known morphism pair member.
-    :param int j: Index of another known morphism pair member.
-    :param dict dict_of_pairs: Dictionary in which to store the set of known morphisms.
-    """
-
-    morphisms = set()
-
-    for index in (i, j):
-        morphisms |= dict_of_pairs[index]
-
-    morphisms |= {i, j}
-
-    for index in morphisms:
-        dict_of_pairs[index] = morphisms - {index}


### PR DESCRIPTION
Fixes #11.

Dit checkt voor het beginnen van het algoritme voor een grafenpaar of reeds bekend is of ze isomorf zijn. Indien bekend, dan wordt dit uitgeprint en gaat het algoritme verder met het volgende paar.